### PR TITLE
Added commands for working with "sets"

### DIFF
--- a/sets.go
+++ b/sets.go
@@ -44,7 +44,7 @@ func setExists(key string) bool {
 
 func init() {
 	registerCommand("sadd", sUsage, 3, 4, sadd)
-	registerCommand("sremove", sUsage, 3, 3, sdel)
+	registerCommand("sdel", sUsage, 3, 3, sdel)
 	registerCommand("sismember", sUsage, 3, 3, sismember)
 	registerCommand("smembers", sUsage, 2, 2, smembers)
 }


### PR DESCRIPTION
The _set_ is a primitive I think could be useful for etcd - either
implemented in the core or on the client-side. Basically they can be
used to store a set of values of the same type under a single key.

An example:

``` bash
$ ./etcdctl setadd /queues amqp://user:password@rabbitmq1
amqp://user:password@rabbitmq1
$ ./etcdctl setadd /queues amqp://user:password@rabbitmq2
amqp://user:password@rabbitmq2
$ ./etcdctl setmembers /queues
"amqp://user:password@rabbitmq1"
"amqp://user:password@rabbitmq1"
# So the server has to re-register itself every minute
$ ./etcdctl setadd /queues amqp://user:password@rabbitmq2 --ttl=60
$ ./etcdctl setremove /queues amqp://user:password@rabbitmq2
```

I created an [issue in etcd](https://github.com/coreos/etcd/issues/48) for this, but we agreed that it'd be better to try it out here, to avoid introducing unnecessary complexity in the core.

The commands I've added are:
- `setadd <key> <value>`
- `setremove <key> <value>`
- `setmembers <key>`
- `setismember <key> <value>`

This is all implemented using the existing `set`, `get` and `delete` commands.

Let me know what you think!
