### PR TITLE
feat(command): change extended to use RFC 2822 format

### DIFF
--- a/command/handle.go
+++ b/command/handle.go
@@ -63,10 +63,12 @@ func printResponse(resp *etcd.Response, format string) {
 	case "simple":
 		fmt.Println(resp.Value)
 	case "extended":
+		// Extended prints in a rfc2822 style format
+		fmt.Println("Key:", resp.Key)
+		fmt.Println("Modified-Index:", resp.ModifiedIndex)
+		fmt.Println("TTL:", resp.TTL)
+		fmt.Println("")
 		fmt.Println(resp.Value)
-		// This style emulates tools like getfacl
-		fmt.Println("# modified-index:", resp.ModifiedIndex)
-		fmt.Println("# ttl:", resp.TTL)
 	case "json":
 		b, err := json.Marshal(resp)
 		if err != nil {

--- a/examples/do-on-change.sh
+++ b/examples/do-on-change.sh
@@ -6,14 +6,14 @@
 # The key to watch
 KEY=config
 
-index_re='s/^# modified-index: \(.*\)/\1/p'
+index_re='s/^Modified-Index: \(.*\)/\1/p'
 
 index=$(./etcdctl -o extended get ${KEY} | sed -n -e "${index_re}")
 
 while true; do
 	out=$(./etcdctl -o extended watch ${KEY} --after-index ${index})
-	config=$(echo "${out}" | grep -v "^#")
 	index=$(echo "${out}" | sed -n -e "${index_re}")
+	config=$(echo "${out}" | sed -e '1,/^$/d')
 
 	# Print out the example command line to execute
 	echo "echo \"${config}\" | config-update"


### PR DESCRIPTION
In the effort not to invent new things lets use a simpler RFC 2822 format for
the extended output of etcdctl.
