### PR TITLE
feat(etcdctl): accept -peers like etcd

### DIFF
--- a/etcdctl.go
+++ b/etcdctl.go
@@ -15,7 +15,7 @@ func main() {
 	app.Flags = []cli.Flag{
 		cli.BoolFlag{"debug", "output cURL commands which can be used to reproduce the request"},
 		cli.StringFlag{"output, o", "simple", "output response in the given format (`simple` or `json`)"},
-		cli.StringSliceFlag{"C", &cli.StringSlice{"127.0.0.1:4001"}, "a comma seperated list of machine addresses in the cluster"},
+		cli.StringSliceFlag{"peers, C", &cli.StringSlice{"127.0.0.1:4001"}, "a comma seperated list of machine addresses in the cluster"},
 	}
 	app.Commands = []cli.Command{
 		command.NewCreateCommand(),


### PR DESCRIPTION
accept -peers instead of -C just like etcd. Fixes #30
