### PR TITLE
fix(command): fixup peers flag to use the same logic from etcd

### DIFF
--- a/command/handle.go
+++ b/command/handle.go
@@ -23,8 +23,8 @@ func dumpCURL(client *etcd.Client) {
 // rawhandle wraps the command function handlers and sets up the
 // environment but performs no output formatting.
 func rawhandle(c *cli.Context, fn handlerFunc) (*etcd.Response, error) {
-	peers := c.GlobalStringSlice("C")
-	client := etcd.NewClient(peers)
+	peers := c.GlobalString("C")
+	client := etcd.NewClient(trimsplit(peers, ","))
 
 	if c.GlobalBool("debug") {
 		go dumpCURL(client)

--- a/command/util.go
+++ b/command/util.go
@@ -1,0 +1,17 @@
+package command
+
+import (
+	"strings"
+)
+
+// trimsplit slices s into all substrings separated by sep and returns a
+// slice of the substrings between the separator with all leading and trailing
+// white space removed, as defined by Unicode.
+func trimsplit(s, sep string) []string {
+	raw := strings.Split(s, ",")
+	trimmed := make([]string, 0)
+	for _, r := range raw {
+		trimmed = append(trimmed, strings.TrimSpace(r))
+	}
+	return trimmed
+}

--- a/etcdctl.go
+++ b/etcdctl.go
@@ -15,7 +15,7 @@ func main() {
 	app.Flags = []cli.Flag{
 		cli.BoolFlag{"debug", "output cURL commands which can be used to reproduce the request"},
 		cli.StringFlag{"output, o", "simple", "output response in the given format (`simple` or `json`)"},
-		cli.StringSliceFlag{"peers, C", &cli.StringSlice{"127.0.0.1:4001"}, "a comma seperated list of machine addresses in the cluster"},
+		cli.StringFlag{"peers, C", "127.0.0.1:4001", "a comma seperated list of machine addresses in the cluster"},
 	}
 	app.Commands = []cli.Command{
 		command.NewCreateCommand(),


### PR DESCRIPTION
StringSlice behaves oddly so just use the same parsing logic from etcd
