### PR TITLE
Various cleanups to improve debug output

### DIFF
--- a/command/handle.go
+++ b/command/handle.go
@@ -24,7 +24,7 @@ func dumpCURL(client *etcd.Client) {
 // rawhandle wraps the command function handlers and sets up the
 // environment but performs no output formatting.
 func rawhandle(c *cli.Context, fn handlerFunc) (*etcd.Response, error) {
-	peers := c.GlobalString("C")
+	peers := c.GlobalString("peers")
 	client := etcd.NewClient(trimsplit(peers, ","))
 
 	if c.GlobalBool("debug") {


### PR DESCRIPTION
The primary feature is outputting the cluster peers to stderr when
--debug is added.

This is to fix #35 

Example output now:

```
./etcdctl --debug --peers 192.168.1.237:4002,192.168.1.233:4003 set foobar 2139081094801
Cluster-Peers: 192.168.1.237:4002 192.168.1.233:4003
Cannot sync with the cluster
```

```
./etcdctl --debug set foobar 2139081094801
Cluster-Peers: http://127.0.0.1:4001 http://127.0.0.1:4003 http://127.0.0.1:4002
Curl-Example: curl -X PUT http://127.0.0.1:4001/v2/keys/foobar -d value=2139081094801
2139081094801
```
