### PR TITLE
refactor rename create to mk

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,14 @@ Goodbye world
 Create a new key `/foo/bar`, only if the key did not previously exist:
 
 ```
-$ etcdctl create /foo/new_bar "Hello world"
+$ etcdctl mk /foo/new_bar "Hello world"
 Hello world
+```
+
+Create a new dir `/fooDir`, only if the key did not previously exist:
+
+```
+$ etcdctl mkdir /fooDir
 ```
 
 Update an existing key `/foo/bar`, only if the key already existed:

--- a/command/mk_command.go
+++ b/command/mk_command.go
@@ -7,22 +7,22 @@ import (
 	"github.com/coreos/go-etcd/etcd"
 )
 
-// NewCreateCommand returns the CLI command for "create".
-func NewCreateCommand() cli.Command {
+// NewMakeCommand returns the CLI command for "mk".
+func NewMakeCommand() cli.Command {
 	return cli.Command{
-		Name:  "create",
-		Usage: "create a new key with a given value",
+		Name:  "mk",
+		Usage: "make a new key with a given value",
 		Flags: []cli.Flag{
 			cli.IntFlag{"ttl", 0, "key time-to-live"},
 		},
 		Action: func(c *cli.Context) {
-			handleKey(c, createCommandFunc)
+			handleKey(c, makeCommandFunc)
 		},
 	}
 }
 
-// createCommandFunc executes the "create" command.
-func createCommandFunc(c *cli.Context, client *etcd.Client) (*etcd.Response, error) {
+// makeCommandFunc executes the "make" command.
+func makeCommandFunc(c *cli.Context, client *etcd.Client) (*etcd.Response, error) {
 	if len(c.Args()) == 0 {
 		return nil, errors.New("Key required")
 	} else if len(c.Args()) == 1 {

--- a/command/mkdir_command.go
+++ b/command/mkdir_command.go
@@ -7,22 +7,22 @@ import (
 	"github.com/coreos/go-etcd/etcd"
 )
 
-// NewCreateDirCommand returns the CLI command for "createDir".
-func NewCreateDirCommand() cli.Command {
+// NewMakeDirCommand returns the CLI command for "mkdir".
+func NewMakeDirCommand() cli.Command {
 	return cli.Command{
-		Name:  "createDir",
-		Usage: "create a new directory",
+		Name:  "mkdir",
+		Usage: "make a new directory",
 		Flags: []cli.Flag{
 			cli.IntFlag{"ttl", 0, "key time-to-live"},
 		},
 		Action: func(c *cli.Context) {
-			handleKey(c, createDirCommandFunc)
+			handleKey(c, makeDirCommandFunc)
 		},
 	}
 }
 
-// createDirCommandFunc executes the "createDir" command.
-func createDirCommandFunc(c *cli.Context, client *etcd.Client) (*etcd.Response, error) {
+// makeDirCommandFunc executes the "mkdir" command.
+func makeDirCommandFunc(c *cli.Context, client *etcd.Client) (*etcd.Response, error) {
 	if len(c.Args()) == 0 {
 		return nil, errors.New("Key required")
 	}

--- a/etcdctl.go
+++ b/etcdctl.go
@@ -18,8 +18,8 @@ func main() {
 		cli.StringFlag{"peers, C", "127.0.0.1:4001", "a comma seperated list of machine addresses in the cluster"},
 	}
 	app.Commands = []cli.Command{
-		command.NewCreateCommand(),
-		command.NewCreateDirCommand(),
+		command.NewMakeCommand(),
+		command.NewMakeDirCommand(),
 		command.NewRemoveCommand(),
 		command.NewRemoveDirCommand(),
 		command.NewGetCommand(),


### PR DESCRIPTION
@polvi  @benbjohnson  @philips 
To follow the unix naming convention, we have renamed `delete` to `rm` and added `rmdir`. 
To make things more consistent, here we renamed `create` to `mk` and `createDir` to `mkdir`.

Let me know how you think about this.
