### PR TITLE
fix(commands/*dir): remove bumpy caps from updatedir and setdir

### DIFF
--- a/command/set_dir_command.go
+++ b/command/set_dir_command.go
@@ -10,7 +10,7 @@ import (
 // NewSetDirCommand returns the CLI command for "setDir".
 func NewSetDirCommand() cli.Command {
 	return cli.Command{
-		Name:  "setDir",
+		Name:  "setdir",
 		Usage: "create a new or existing directory",
 		Flags: []cli.Flag{
 			cli.IntFlag{"ttl", 0, "key time-to-live"},

--- a/command/update_dir_command.go
+++ b/command/update_dir_command.go
@@ -10,7 +10,7 @@ import (
 // NewUpdateDirCommand returns the CLI command for "updateDir".
 func NewUpdateDirCommand() cli.Command {
 	return cli.Command{
-		Name:  "updateDir",
+		Name:  "updatedir",
 		Usage: "update an existing directory",
 		Flags: []cli.Flag{
 			cli.IntFlag{"ttl", 0, "key time-to-live"},


### PR DESCRIPTION
Everything else in this tool uses lower case. Lower case these two commands
too.
