### PR TITLE
fix(commands/*dir): don't print key after success

### DIFF
--- a/command/handle.go
+++ b/command/handle.go
@@ -58,9 +58,15 @@ func handlePrint(c *cli.Context, fn handlerFunc, pFn printFunc) {
 		os.Exit(ErrorFromEtcd)
 	}
 
-	if resp != nil {
+	if resp != nil && pFn != nil {
 		pFn(resp, c.GlobalString("output"))
 	}
+}
+
+// handleDir handles a request that wants to do operations on a single dir.
+// Dir cannot be printed out, so we set NIL print function here.
+func handleDir(c *cli.Context, fn handlerFunc) {
+	handlePrint(c, fn, nil)
 }
 
 // handleKey handles a request that wants to do operations on a single key.

--- a/command/mkdir_command.go
+++ b/command/mkdir_command.go
@@ -16,7 +16,7 @@ func NewMakeDirCommand() cli.Command {
 			cli.IntFlag{"ttl", 0, "key time-to-live"},
 		},
 		Action: func(c *cli.Context) {
-			handleKey(c, makeDirCommandFunc)
+			handleDir(c, makeDirCommandFunc)
 		},
 	}
 }

--- a/command/rmdir_command.go
+++ b/command/rmdir_command.go
@@ -13,7 +13,7 @@ func NewRemoveDirCommand() cli.Command {
 		Name:	"rmdir",
 		Usage:	"removes the key if it is an empty directory or a key-value pair",
 		Action: func(c *cli.Context) {
-			handleKey(c, removeDirCommandFunc)
+			handleDir(c, removeDirCommandFunc)
 		},
 	}
 }

--- a/command/set_dir_command.go
+++ b/command/set_dir_command.go
@@ -16,7 +16,7 @@ func NewSetDirCommand() cli.Command {
 			cli.IntFlag{"ttl", 0, "key time-to-live"},
 		},
 		Action: func(c *cli.Context) {
-			handleKey(c, setDirCommandFunc)
+			handleDir(c, setDirCommandFunc)
 		},
 	}
 }

--- a/command/update_dir_command.go
+++ b/command/update_dir_command.go
@@ -16,7 +16,7 @@ func NewUpdateDirCommand() cli.Command {
 			cli.IntFlag{"ttl", 0, "key time-to-live"},
 		},
 		Action: func(c *cli.Context) {
-			handleKey(c, updateDirCommandFunc)
+			handleDir(c, updateDirCommandFunc)
 		},
 	}
 }


### PR DESCRIPTION
fix #56
fix #57

Because we cannot print directory key, don't print key even if directory
operations succeed.
