### PR TITLE
fix(command): use unix style error messages

### DIFF
--- a/command/get_command.go
+++ b/command/get_command.go
@@ -32,7 +32,7 @@ func handleGet(c *cli.Context, fn handlerFunc) {
 // printGet writes error message when getting the value of a directory.
 func printGet(resp *etcd.Response, format string) {
 	if resp.Node.Dir {
-		fmt.Fprintln(os.Stderr, fmt.Sprintf("Cannot get the value [%s: Is a directory]\nPlease use ls to list a directory", resp.Node.Key))
+		fmt.Fprintln(os.Stderr, fmt.Sprintf("%s: is a directory", resp.Node.Key))
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
These simple etcdctl utilities should try and follow the unix philosophy as
much as possible. Return short useful errors, exit with 1.

Example from rm:

```
$ rm third_party
rm: third_party: is a directory
$ echo $?
1
```
