### PR TITLE
chore(flag): Use StringSliceFlag for --peers

### DIFF
--- a/command/handle.go
+++ b/command/handle.go
@@ -40,7 +40,7 @@ func createHttpPath(addr string) (string, error) {
 func rawhandle(c *cli.Context, fn handlerFunc) (*etcd.Response, error) {
 	sync := !c.GlobalBool("no-sync")
 
-	peers := trimsplit(c.GlobalString("peers"), ",")
+	peers := c.GlobalStringSlice("peers")
 	// If no sync, create http path for each peer address
 	if !sync {
 		revisedPeers := make([]string, 0)

--- a/etcdctl.go
+++ b/etcdctl.go
@@ -16,7 +16,7 @@ func main() {
 		cli.BoolFlag{"debug", "output cURL commands which can be used to reproduce the request"},
 		cli.BoolFlag{"no-sync", "don't synchronize cluster information before sending request"},
 		cli.StringFlag{"output, o", "simple", "output response in the given format (`simple` or `json`)"},
-		cli.StringFlag{"peers, C", "127.0.0.1:4001", "a comma seperated list of machine addresses in the cluster"},
+		cli.StringSliceFlag{"peers, C", &cli.StringSlice{"127.0.0.1:4001"}, "a comma-delimited list of machine addresses in the cluster"},
 	}
 	app.Commands = []cli.Command{
 		command.NewMakeCommand(),


### PR DESCRIPTION
cli library supports string slice as a flag, and uses here
to make code cleaner.
@bcwaldon
