### PR TITLE
fix(options): handle default -peer correctly

### DIFF
--- a/command/handle.go
+++ b/command/handle.go
@@ -41,6 +41,10 @@ func rawhandle(c *cli.Context, fn handlerFunc) (*etcd.Response, error) {
 	sync := !c.GlobalBool("no-sync")
 
 	peers := c.GlobalStringSlice("peers")
+	// Append default peer address if not any
+	if len(peers) == 0 {
+		peers = append(peers, "127.0.0.1:4001")
+	}
 	// If no sync, create http path for each peer address
 	if !sync {
 		revisedPeers := make([]string, 0)

--- a/etcdctl.go
+++ b/etcdctl.go
@@ -16,7 +16,7 @@ func main() {
 		cli.BoolFlag{"debug", "output cURL commands which can be used to reproduce the request"},
 		cli.BoolFlag{"no-sync", "don't synchronize cluster information before sending request"},
 		cli.StringFlag{"output, o", "simple", "output response in the given format (`simple` or `json`)"},
-		cli.StringSliceFlag{"peers, C", &cli.StringSlice{"127.0.0.1:4001"}, "a comma-delimited list of machine addresses in the cluster"},
+		cli.StringSliceFlag{"peers, C", &cli.StringSlice{}, "a comma-delimited list of machine addresses in the cluster (default: {\"127.0.0.1:4001\"})"},
 	}
 	app.Commands = []cli.Command{
 		command.NewMakeCommand(),


### PR DESCRIPTION
Use default peer address only when the user doesn't set `-peers`.

@bcwaldon
