### PR TITLE
Update exec_watch_command.go

### DIFF
--- a/command/exec_watch_command.go
+++ b/command/exec_watch_command.go
@@ -37,22 +37,26 @@ func execWatchCommandFunc(c *cli.Context, client *etcd.Client) (*etcd.Response, 
 	if argsLen < 2 {
 		return nil, errors.New("Key and command to exec required")
 	}
-
-	key := args[argsLen-1]
-	cmdArgs := args[:argsLen-1]
+	
+	//does not match the command description, changing to 
+	//reflect usage of etcdtcl -C IP:Port exec-watch KEY CMD CMD_ARGS
+	//should only need to do this here.  Not inside of checks for after index, and recursive
+	key := args[0]
+	cmdArgs := args[1:]
 
 	index := 0
 	if c.Int("after-index") != 0 {
 		index = c.Int("after-index") + 1
-		key = args[0]
-		cmdArgs = args[2:]
+		//redundant with above declaration if cli option handling is working,ck
+		//key = args[0]
+		//cmdArgs = args[1:]
 	}
-
-	recursive := c.Bool("recursive")
-	if recursive != false {
-		key = args[0]
-		cmdArgs = args[2:]
-	}
+	//entirely superfluous,ck  
+	//recursive := c.Bool("recursive")
+	//if recursive != false {
+	//	key = args[0]
+	//	cmdArgs = args[1:]
+	//}
 
 	sigch := make(chan os.Signal, 1)
 	signal.Notify(sigch, os.Interrupt)


### PR DESCRIPTION
Exec-watch command does not work as documented.  Changed to match the help provided by the usage statement.
