### PR TITLE
refactor(errors): move error calls and output to error class

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ $ etcdctl rm /foo/bar
 Delete an empty directory or a key-value pair
 
 ```
-$ etcdctl rmdir /path/to/dir 
+$ etcdctl rmdir /path/to/dir
 ```
 
 or

--- a/command/error.go
+++ b/command/error.go
@@ -1,5 +1,10 @@
 package command
 
+import (
+	"fmt"
+	"os"
+)
+
 const (
 	SUCCESS = iota
 	MalformedEtcdctlArguments
@@ -7,3 +12,8 @@ const (
 	FailedToAuth
 	ErrorFromEtcd
 )
+
+func handleError(code int, err error) {
+	fmt.Fprintln(os.Stderr, "Error: ", err)
+	os.Exit(code)
+}

--- a/command/handle.go
+++ b/command/handle.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -67,8 +68,7 @@ func rawhandle(c *cli.Context, fn handlerFunc) (*etcd.Response, error) {
 	// Sync cluster.
 	if sync {
 		if ok := client.SyncCluster(); !ok {
-			fmt.Println("Cannot sync with the cluster using peers", peers)
-			os.Exit(FailedToConnectToHost)
+			handleError(FailedToConnectToHost, errors.New("Cannot sync with the cluster using peers " + strings.Join(peers, ", ")))
 		}
 	}
 
@@ -88,8 +88,7 @@ func handlePrint(c *cli.Context, fn handlerFunc, pFn printFunc) {
 
 	// Print error and exit, if necessary.
 	if err != nil {
-		fmt.Println("Error:", err)
-		os.Exit(ErrorFromEtcd)
+		handleError(ErrorFromEtcd, err)
 	}
 
 	if resp != nil && pFn != nil {

--- a/command/watch_command.go
+++ b/command/watch_command.go
@@ -2,7 +2,6 @@ package command
 
 import (
 	"errors"
-	"fmt"
 	"os"
 	"os/signal"
 
@@ -63,8 +62,7 @@ func watchCommandFunc(c *cli.Context, client *etcd.Client) (*etcd.Response, erro
 			case resp := <-receiver:
 				printAll(resp, c.GlobalString("output"))
 			case err := <-errCh:
-				fmt.Println("Error:", err)
-				os.Exit(-1)
+				handleError(-1, err)
 			}
 		}
 
@@ -74,8 +72,7 @@ func watchCommandFunc(c *cli.Context, client *etcd.Client) (*etcd.Response, erro
 		resp, err = client.Watch(key, uint64(index), recursive, nil, nil)
 
 		if err != nil {
-			fmt.Println("Error:", err)
-			os.Exit(ErrorFromEtcd)
+			handleError(ErrorFromEtcd, err)
 		}
 
 		if err != nil {


### PR DESCRIPTION
This is the start of a better wrapper to handle errors. It also
prints error text to stderr instead of stdout.
