### PR TITLE
Peer configuration via ETCDCTL_PEERS env variable

### DIFF
--- a/command/handle.go
+++ b/command/handle.go
@@ -44,7 +44,13 @@ func rawhandle(c *cli.Context, fn handlerFunc) (*etcd.Response, error) {
 	peers := c.GlobalStringSlice("peers")
 	// Append default peer address if not any
 	if len(peers) == 0 {
-		peers = append(peers, "127.0.0.1:4001")
+		peers_from_environment := os.Getenv("ETCDCTL_PEERS")
+
+		if peers_from_environment != "" {
+			peers = strings.Split(peers_from_environment, ",")
+		} else {
+			peers = append(peers, "127.0.0.1:4001")
+		}
 	}
 	// If no sync, create http path for each peer address
 	if !sync {

--- a/etcdctl.go
+++ b/etcdctl.go
@@ -16,7 +16,7 @@ func main() {
 		cli.BoolFlag{"debug", "output cURL commands which can be used to reproduce the request"},
 		cli.BoolFlag{"no-sync", "don't synchronize cluster information before sending request"},
 		cli.StringFlag{"output, o", "simple", "output response in the given format (`simple` or `json`)"},
-		cli.StringSliceFlag{"peers, C", &cli.StringSlice{}, "a comma-delimited list of machine addresses in the cluster (default: {\"127.0.0.1:4001\"})"},
+		cli.StringSliceFlag{"peers, C", &cli.StringSlice{}, "a list of peers in the cluster, specify multiple times for multiple peers. (default: 127.0.0.1:4001 or ETCDCTL_PEERS environment variable)"},
 	}
 	app.Commands = []cli.Command{
 		command.NewMakeCommand(),


### PR DESCRIPTION
Add an environment variable for configuring peers.  We have many clusters with individual etcd clusters and we can set this environment variable on each machine in their respective clusters, then we can just run `etcdctl ..` commands without specifying `--peers` each time.

This was the obvious way to implement it, but could be done another way if there are better ways (default in `etcdctl.go`, maybe?).
