### PR TITLE
Make --peers handling match cli help and ETCDCTL_PEERS handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,10 +241,14 @@ The following exit codes can be returned from etcdctl:
 ## Peers
 
 If your etcd cluster isn't available on `http://127.0.0.1:4001` you can specify
-a `--peers` flag or `ETCDCTL_PEERS` environment variable.
+a `--peers` flag or `ETCDCTL_PEERS` environment variable. You can list one peer,
+or a comma-separated list of peers.
 
 ```
 ETCDCTL_PEERS="http://10.0.28.1:4002" etcdctl set my-key to-a-value
+ETCDCTL_PEERS="http://10.0.28.1:4002,http://10.0.28.2:4002,http://10.0.28.3:4002" etcdctl set my-key to-a-value
+etcdctl --peers http://10.0.28.1:4002 my-key to-a-value
+etcdctl --peers http://10.0.28.1:4002,http://10.0.28.2:4002,http://10.0.28.3:4002 etcdctl set my-key to-a-value
 ```
 
 ## Project Details

--- a/command/handle.go
+++ b/command/handle.go
@@ -41,17 +41,21 @@ func createHttpPath(addr string) (string, error) {
 func rawhandle(c *cli.Context, fn handlerFunc) (*etcd.Response, error) {
 	sync := !c.GlobalBool("no-sync")
 
-	peers := c.GlobalStringSlice("peers")
-	// Append default peer address if not any
-	if len(peers) == 0 {
-		peers_from_environment := os.Getenv("ETCDCTL_PEERS")
+	peerstr := c.GlobalString("peers")
 
-		if peers_from_environment != "" {
-			peers = strings.Split(peers_from_environment, ",")
-		} else {
-			peers = append(peers, "127.0.0.1:4001")
-		}
+	// Use an environment variable if nothing was supplied on the
+	// command line
+	if peerstr == "" {
+		peerstr = os.Getenv("ETCDCTL_PEERS")
 	}
+	
+	// If we still don't have peers, use a default
+	if peerstr == "" {
+		peerstr = "127.0.0.1:4001"
+	}
+
+	peers := strings.Split(peerstr, ",")
+
 	// If no sync, create http path for each peer address
 	if !sync {
 		revisedPeers := make([]string, 0)

--- a/etcdctl.go
+++ b/etcdctl.go
@@ -16,7 +16,7 @@ func main() {
 		cli.BoolFlag{"debug", "output cURL commands which can be used to reproduce the request"},
 		cli.BoolFlag{"no-sync", "don't synchronize cluster information before sending request"},
 		cli.StringFlag{"output, o", "simple", "output response in the given format (`simple` or `json`)"},
-		cli.StringSliceFlag{"peers, C", &cli.StringSlice{}, "a comma-delimited list of machine addresses in the cluster (default: \"127.0.0.1:4001\")"},
+		cli.StringFlag{"peers, C", "", "a comma-delimited list of machine addresses in the cluster (default: \"127.0.0.1:4001\")"},
 	}
 	app.Commands = []cli.Command{
 		command.NewMakeCommand(),


### PR DESCRIPTION
The cli help for etcdctl says that you can supply "a
comma-delimited list of machine addresses in the cluster". This
does in fact work for the ETCDCTL_PEERS environment variable,
but does not work if you use the --peers flag.

Change the handling of peer configuration so it works uniformly
between the --peers flag and the ETCDCTL_PEERS environment
variable.
