### PR TITLE
Adding support for SSL/TLS client connection

### DIFF
--- a/etcdctl.go
+++ b/etcdctl.go
@@ -17,6 +17,9 @@ func main() {
 		cli.BoolFlag{"no-sync", "don't synchronize cluster information before sending request"},
 		cli.StringFlag{"output, o", "simple", "output response in the given format (`simple` or `json`)"},
 		cli.StringSliceFlag{"peers, C", &cli.StringSlice{}, "a comma-delimited list of machine addresses in the cluster (default: \"127.0.0.1:4001\")"},
+		cli.StringFlag{"ca-file", "", "Path to the client CA file."},
+		cli.StringFlag{"cert-file", "", "Path to the client cert file."},
+		cli.StringFlag{"key-file", "", "Path to the client key file."},
 	}
 	app.Commands = []cli.Command{
 		command.NewMakeCommand(),


### PR DESCRIPTION
Allows `etcdctl` to work with `etcd` when using client certificates.

_testing:_

Start `etcd` with the following client communication options

``` bash
$ etcd -name server \
  -data-dir=. \
  -ca-file=<(curl -s https://gist.githubusercontent.com/philipsoutham/b33c2bbe83eaf46b4833/raw/ecc790e23d0146c13dfbf1ece62a84e45d51f0f4/ca.crt) \
  -cert-file=<(curl -s https://gist.githubusercontent.com/philipsoutham/b33c2bbe83eaf46b4833/raw/a33d7d572ec6003a66de2f9d6d667cbb8479c411/server.crt) \
  -key-file=<(curl -s https://gist.githubusercontent.com/philipsoutham/b33c2bbe83eaf46b4833/raw/26dd9085592f2e6127a009d50daef482c0f97f47/server.key)
```

Verify it works.

``` bash
$ etcdctl -o json \
  -peers "127.0.0.1:4001" \
  -ca-file=<(curl -s https://gist.githubusercontent.com/philipsoutham/b33c2bbe83eaf46b4833/raw/ecc790e23d0146c13dfbf1ece62a84e45d51f0f4/ca.crt) \
  -cert-file=<(curl -s https://gist.githubusercontent.com/philipsoutham/b33c2bbe83eaf46b4833/raw/4646d4afa80069997d6698f1c45319633ae840d0/client.crt) \
  -key-file=<(curl -s https://gist.githubusercontent.com/philipsoutham/b33c2bbe83eaf46b4833/raw/8bd324b88bf3d643f43a27add6ef21406ad8eab7/client.key) \
  mk foo bar


$ etcdctl -o json \
  -peers "127.0.0.1:4001" \
  -ca-file=<(curl -s https://gist.githubusercontent.com/philipsoutham/b33c2bbe83eaf46b4833/raw/ecc790e23d0146c13dfbf1ece62a84e45d51f0f4/ca.crt) \
  -cert-file=<(curl -s https://gist.githubusercontent.com/philipsoutham/b33c2bbe83eaf46b4833/raw/4646d4afa80069997d6698f1c45319633ae840d0/client.crt) \
  -key-file=<(curl -s https://gist.githubusercontent.com/philipsoutham/b33c2bbe83eaf46b4833/raw/8bd324b88bf3d643f43a27add6ef21406ad8eab7/client.key) \
  get foo
```
